### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "esoteric-vm"
 version = "0.2.1"
 edition = "2021"
-repository = "https://www.github.com/tadaHrd/esoteric-vm"
+repository = "https://github.com/tadaHrd/esoteric-vm"
 description = "An esoteric virtual machine"
 license = "MIT"
 


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96